### PR TITLE
Adding a tabular representation of the orderbook

### DIFF
--- a/order.go
+++ b/order.go
@@ -98,3 +98,18 @@ func (o *Order) UnmarshalJSON(data []byte) error {
 	o.price = obj.Price
 	return nil
 }
+
+// GetOrderSide gets the orderside along with its orders in one side of the market
+func (ob *OrderBook) GetOrderSide(side Side) *OrderSide {
+	switch side {
+	case Buy:
+		return ob.bids
+	default:
+		return ob.asks
+	}
+}
+
+// MarketOverview gives an overview of the market including the quantities and prices of each side in the market
+func (os *OrderSide) MarketOverview() {
+	// Todo
+}

--- a/order.go
+++ b/order.go
@@ -136,7 +136,7 @@ func (ob *OrderBook) MarketOverview() *MarketView {
 
 // compileOrders compiles orders in the following format
 func compileOrders(orders []*list.Element) map[int]QueueTuple {
-
+	// show queue
 	queue := make(map[int]QueueTuple)
 
 	for i, o := range orders {

--- a/order.go
+++ b/order.go
@@ -110,6 +110,6 @@ func (ob *OrderBook) GetOrderSide(side Side) *OrderSide {
 }
 
 // MarketOverview gives an overview of the market including the quantities and prices of each side in the market
-func (os *OrderSide) MarketOverview() {
-	// Todo
-}
+// func (os *OrderSide) MarketOverview() {
+// 	// Todo
+// }


### PR DESCRIPTION
In some cases, users should see a brief overview of the orderbook. For instance, *user A* should see the following representation of both the queues in the orderbook:

```
         Asks (  qty,   price)                              Bids ( qty,   price)
                      2       1.5                                             4     1
                      3       1.8                                              3     0.8
                      3        2                                                2     0.75
```
In the suggested changes, I have added a MarketView method that delivers the expected info in the ```map[string]decimal.Decimal``` in which keys are prices and the values are quantities.

Why strings as the keys? I used built-in string type rather than decimal.Decimal since the latter creates two objects for very same numbers:
```
	a := decimal.NewFromFloat(1)
	b := decimal.NewFromFloat(1)
	fmt.Printf("%v and %v are equal? %v\n", a, b, a == b)
        //  1 and 1 are equal? false
```